### PR TITLE
Improve hypy pysim output

### DIFF
--- a/src/hybridpy/hybridpy/pysim/simulate.py
+++ b/src/hybridpy/hybridpy/pysim/simulate.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 from matplotlib import colors
 import random
 from scipy.integrate import ode # pylint false positive
+import numpy as np
 
 class PySimSettings(object):
     'A pysim settings containts'
@@ -653,7 +654,21 @@ def _plot_sim_result_one(result, dim_x, dim_y, draw_events=True, mode_to_color=N
 
             plt.plot(x, y, 'xr')
 
-
+def interval_bounds_from_sim_result_multi(result_list):
+    '''
+    return the componentwise interval bounds [min(x_i), max(x_i)] 
+    as np.array with shape (n, 2), where n is the number of states
+    '''
+    assert len(result_list) > 0, 'empty list of simulations; cannot compute maximum'
+    num_states = len(result_list[0]['traces'][0].points[0])
+    state_max = np.zeros((num_states, 1));
+    state_min = np.zeros((num_states, 1));
+    for result in result_list:
+        for mode_sim in result['traces']:
+            for dim in range(num_states):
+                state_max[dim] = max(state_max[dim], max([val[dim] for val in mode_sim.points]))
+                state_min[dim] = min(state_min[dim], min([val[dim] for val in mode_sim.points]))
+    return np.block([state_min, state_max])
 
 
 

--- a/src/hybridpy/hybridpy/test_hypy.py
+++ b/src/hybridpy/hybridpy/test_hypy.py
@@ -7,7 +7,7 @@ import os
 
 # assumes hybridpy is on your PYTHONPATH
 import hybridpy.hypy as hypy
-
+import numpy as np
 
 def get_script_dir():
     '''get the dir path this script'''
@@ -24,9 +24,11 @@ class TestHypy(unittest.TestCase):
         e = hypy.Engine('pysim')
         e.set_input(model) # sets input model path
 
-        res = e.run()
+        res = e.run(parse_output=True)
         
         self.assertEqual(res['code'], hypy.Engine.SUCCESS)
+        np.testing.assert_allclose(res['output']['interval_bounds'], np.array([[0, 9],[0, 20], [0, 20]]))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/hybridpy/hybridpy/tool_pysim.py
+++ b/src/hybridpy/hybridpy/tool_pysim.py
@@ -3,6 +3,8 @@
 import imp
 import os
 import sys
+import pickle
+import tempfile
 
 from hybridpy.hybrid_tool import HybridTool
 from hybridpy.hybrid_tool import RunCode
@@ -40,7 +42,11 @@ class PySimTool(HybridTool):
 
         self._init_states = define_init_states(define_ha())
         self._result = sim(self._init_states, self._settings)
-
+        # We need to pass the result via stdout (see note in parse_output()).
+        # To do that, we serialize and write it to a file and print the filename.
+        with tempfile.NamedTemporaryFile(prefix='pysim_result',suffix='.pickle', delete=False) as filehandle:
+            pickle.dump(self._result, filehandle)
+            print "PYSIM_RESULT_FILE=" + filehandle.name
         return rv
 
     def _make_image(self):
@@ -54,12 +60,26 @@ class PySimTool(HybridTool):
 
         return True
 
-    def parse_output(self, dummy_directory, dummy_lines, dummy_hypy_out):
+    def parse_output(self, dummy_directory, lines, dummy_hypy_out):
         '''returns the parsed output object
 
         For pysim, this is the result of running simulate()
         '''
-
+        # NOTE: This function is not called on the same tool object as _run_tool and _make_image because these are run in a subprocess,
+        # whereas parse_output is run in the main python process that called hypy.Engine.run().
+        # Additionally, the temporary directory gets deleted before parse_output is called.
+        # Therefore, the data must be passed via stdout.
+        
+        prefix = "PYSIM_RESULT_FILE="
+        for line in lines:
+            if line.startswith(prefix):
+                # import data printed from _run_tool()
+                path = line[len(prefix):]
+                with open(path, 'rb') as f:
+                    self._result = pickle.load(f)
+                os.remove(path)
+            
+        assert self._result is not None, "could not find {} in output".format(prefix)
         return self._result
                 
 if __name__ == "__main__":


### PR DESCRIPTION
If pysim is called via hypy with `parse_output=True`, the output was `None` due to a bug. This change fixes the bug and adds additional output: Not only the simulation results, but also interval bounds and variable names are now returned in `hypy.Engine('pysim').run()['output']`.

This should simplify future unit-testing and numerically comparing tools.

Unittests pass (if this pull request is combined with my other requests for fixing bugs in the unittests).