### PR TITLE
re-add 'hyst' command

### DIFF
--- a/hyst
+++ b/hyst
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec java -jar "$(dirname $0)/src/Hyst.jar" "$@"


### PR DESCRIPTION
The script which provides the 'hyst' shortcut for 'java -jar Hyst.jar' was accidentally removed in 93552275fe94229bcbb74435d6309ce95f969d40

Re-add it because it is referenced in the documentation (Dockerfile comments).


All tests pass.
