### PR TITLE
Minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ TAGS
 .\#*
 src/.gitignore
 *junitvmwatcher*
+*.orig
+*.kate-swp

--- a/src/hybridpy/hybridpy/pysim/simulate.py
+++ b/src/hybridpy/hybridpy/pysim/simulate.py
@@ -226,6 +226,7 @@ def init_list_to_q_list(init_states, center=True, star=True, corners=False, tol=
     '''
 
     rv = []
+    random.seed(0) # ensure repeatable random results
 
     for init in init_states:
         mode = init[0]
@@ -243,8 +244,6 @@ def init_list_to_q_list(init_states, center=True, star=True, corners=False, tol=
                 rv.append((mode, point))
 
         if rand > 0:
-            random.seed()
-
             max_rand_attempts = 100 * rand
             num_added = 0
 

--- a/src/hybridpy/hybridpy/tool_hylaa2.py
+++ b/src/hybridpy/hybridpy/tool_hylaa2.py
@@ -29,7 +29,7 @@ class Hylaa2Tool(HybridTool):
             params = [self.tool_path, self.model_path]
             
             if image_requested:
-                params.append('image.png')
+                params.append(self.image_path)
 
             proc = subprocess.Popen(params)
             proc.wait()

--- a/src/java/com/verivital/hyst/printers/SpaceExPrinter.java
+++ b/src/java/com/verivital/hyst/printers/SpaceExPrinter.java
@@ -90,7 +90,7 @@ public class SpaceExPrinter extends ToolPrinter
 	@Option(name = "-time_triggered", usage = "sets map-zero-duration-jump-sets=true")
 	boolean isTimeTriggered = false;
 
-	@Option(name = "-output_vars", usage = "comma-separated output variables", metaVar = "VAL")
+	@Option(name = "-output_vars", usage = "comma-separated output variables, or '*' to select all variables", metaVar = "VAL")
 	String outputVars = "auto";
 
 	private String cfgFilename = null;
@@ -409,6 +409,13 @@ public class SpaceExPrinter extends ToolPrinter
 		{
 			for (String v : config.settings.plotVariableNames)
 				sed.addOutputVar(v);
+		}
+		else if (outputVars.equals("*"))
+		{
+			for (String v : ha.variables)
+			{
+				sed.addOutputVar(v);
+			}
 		}
 		else
 		{


### PR DESCRIPTION
- To allow for repeatable execution of pysim and "random initial points", I changed it to use a constant seed value. Before, the seed was always random and there was no way to configure the seed. I assume nobody explicitly depends on the previous behavior.
- The `-output_vars` option for SpaceEx now supports the value `*` to use all variables without explicitly listing them.