### PR TITLE
Download and installation script for local VM without Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ TAGS
 src/.gitignore
 *junitvmwatcher*
 *.orig
+Dockerfile.sh
 *.kate-swp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dockerfile-to-shell-script"]
+	path = dockerfile-to-shell-script
+	url = https://github.com/MaxGaukler/dockerfile-to-shell-script

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ##################
 # Install Hyst dependencies
 ##################
-RUN apt-get update && apt-get -qy install ant python2.7 python-scipy python-matplotlib git libglpk-dev build-essential python-cvxopt python-sympy gimp
-
+RUN apt-get update && apt-get -qy install ant python2.7 python-scipy python-matplotlib git libglpk-dev build-essential python-cvxopt gimp # python-sympy 
 # Bug in sympy < 1.2: "TypeError: argument is not an mpz" (probably https://github.com/sympy/sympy/issues/7457, was fixed Nov 2017)
 # -> we use sympy 1.2
 RUN apt-get -qy install python-pip python-sympy- && pip install sympy==1.2
@@ -85,7 +84,7 @@ RUN spaceex --version
 ENV DREAL_VERSION 3.16.06.02
 ENV DREAL_FILE_SHA512SUM '199c02d90d3d448dff6b9d2d1b99257d4ae4efcf22fa4d66d30eeb0cb6215b06ff8824c4256bf1b89ebaf01b872655ab3105d298c3db0a28d6c0c71a24fa0712'
 
-
+RUN mkdir -p /tools/dreach
 WORKDIR /tools/dreach
 
 RUN curl -fL https://github.com/stanleybak/hybrid_tools/raw/master/dReal-3.16.06.02-linux.tar.gz > dreach.tar.gz

--- a/download_and_install_on_ubuntu_18_04.sh
+++ b/download_and_install_on_ubuntu_18_04.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+# This script will download and install Hyst in /hyst and all relevant tools in /tools.
+#
+# To run this script without download, run the following command in a terminal:
+# wget -q -O download.sh https://raw.githubusercontent.com/verivital/hyst/master/download_and_install_on_ubuntu_18_04.sh && bash download.sh
+sudo apt-get update
+sudo apt-get -qy install git
+cd ~
+rm -rf ./hyst-temp
+git clone https://github.com/verivital/hyst hyst-temp --branch=master --recurse-submodules 
+cd hyst-temp
+sudo -H ./install_on_ubuntu_18_04.sh
+
+sudo chown -R $USER "${HYST_PREFIX}/tools"
+sudo chown -R $USER "${HYST_PREFIX}/hyst"
+cd ..
+rm -rf ./hyst-temp

--- a/install_on_ubuntu_18_04.sh
+++ b/install_on_ubuntu_18_04.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# USAGE:
+# - Install an Ubuntu 18.04 VM
+# - Unpack the Hyst repository somewhere
+# - Open a terminal in the directory containing this file
+# - Run this script as root (or with sudo: sudo ./install_ubuntu_18_04.sh)
+# -> Hyst can be found in the current directory (or as a symlink in /opt/hyst), and the tools at /opt/tools.
+
+# HOW IT WORKS:
+#  Just like sausage, it tastes good but you rather don't want to know how it is made ;-)
+#  We parse the Dockerfile to get a shell script and then run it. Yes, that's ugly.
+
+
+# exit if anything fails
+set -e
+set -o pipefail
+shopt -s failglob
+
+if [[ ! -e ./dockerfile-to-shell-script ]]; then
+    echo "Cannot find the dockerfile-to-shell-script directory. Make sure you are running this script from the current directory. Make sure that the git submodule is checked out -- try 'git submodule --update --init'."
+    exit 1
+fi
+
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root or with sudo" 
+   exit 1
+fi
+
+SCRIPT_PATH="$(readlink -f "$0")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+
+# where should hyst and the tools be installed? Default: /opt
+#HYST_PREFIX=${HYST_PREFIX:-/opt}
+# TODO - this needs extra support in the Dockerfile.
+HYST_PREFIX="/"
+
+echo "This script will install hyst at ${HYST_PREFIX}/hyst, and install its dependencies at ${HYST_PREFIX}/tools."
+
+echo "DO NOT RUN THIS DIRECTLY ON YOUR NORMAL COMPUTER, ONLY IN AN EXTRA VIRTUAL MACHINE,"
+echo "because some of the script's actions will permanently change configuration, uninstall packages et cetera."
+
+echo "CAUTION: all existing content in the the ${HYST_PREFIX}/tools and ${HYST_PREFIX}/hyst folders will be removed."
+
+if tty -s; then
+    # ask for confirmation if interactive session
+    echo "Press Ctrl-C to exit, Enter to continue."
+    read
+fi
+
+mkdir -p "${HYST_PREFIX}"
+rm -rf "${HYST_PREFIX}/tools" "${HYST_PREFIX}/hyst"
+
+./dockerfile-to-shell-script/docker_to_sh.sh # converts Dockerfile to Dockerfile.sh
+./Dockerfile.sh
+
+# save environment variables to file
+grep "export " Dockerfile.sh | sudo sh -c "cat > ${HYST_PREFIX}/hyst_environment"
+
+# automatically load environment variables on login
+echo "source '${HYST_PREFIX}/hyst_environment'" > /etc/profile.d/99-hyst.sh
+
+echo "You need to log in and out again to load the required environment variables. Or run the following command:"
+echo "source '${HYST_PREFIX}/hyst_environment'"
+echo ""
+echo "The tools are then available on the command line (hyst, spaceex, ...)."


### PR DESCRIPTION
Docker is nice, but sometimes makes it awkward to interactively develop (graphical debugging, image output, GUIs). Therefore I created a script which runs the Dockerfile locally, and also takes care of the environment variables (PATH).

This makes it a lot easier for students to get started - they just have to download and run the `download_and_install` script in a VM.

(If you like, I can also directly include the `dockerfile-to-shell-script` utility instead of using a git submodule.)