### PR TITLE
test coverage for Python code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ TAGS
 
 \#*\#
 .\#*
-src/.gitignore
 *junitvmwatcher*
 *.orig
 Dockerfile.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 ##################
 # Install Hyst dependencies
 ##################
-RUN apt-get update && apt-get -qy install ant python2.7 python-scipy python-matplotlib git libglpk-dev build-essential python-cvxopt gimp # python-sympy 
+RUN apt-get update && apt-get -qy install ant python2.7 python-scipy python-matplotlib git libglpk-dev build-essential python-cvxopt python-coverage gimp # python-sympy
+
 # Bug in sympy < 1.2: "TypeError: argument is not an mpz" (probably https://github.com/sympy/sympy/issues/7457, was fixed Nov 2017)
 # -> we use sympy 1.2
 RUN apt-get -qy install python-pip python-sympy- && pip install sympy==1.2
@@ -84,7 +85,7 @@ RUN spaceex --version
 ENV DREAL_VERSION 3.16.06.02
 ENV DREAL_FILE_SHA512SUM '199c02d90d3d448dff6b9d2d1b99257d4ae4efcf22fa4d66d30eeb0cb6215b06ff8824c4256bf1b89ebaf01b872655ab3105d298c3db0a28d6c0c71a24fa0712'
 
-RUN mkdir -p /tools/dreach
+
 WORKDIR /tools/dreach
 
 RUN curl -fL https://github.com/stanleybak/hybrid_tools/raw/master/dReal-3.16.06.02-linux.tar.gz > dreach.tar.gz
@@ -123,10 +124,12 @@ CMD ant test
 # docker run hyst
 # # get a shell:
 # docker run -it hyst bash
-# -> Hyst is available in /hyst/src (run via 'java -jar Hyst.jar'), tools are in /tools, all tools are on the path (e.g. 'spaceex --help')
+# -> Hyst is available in /hyst/src, tools are in /tools, everything is on the path (try 'hyst -help', 'spaceex --help')
 # # run Hyst:
-# docker run hyst java -jar Hyst.jar -help
+# docker run hyst hyst -help
+# # run Hyst via java path:
+# docker run hyst java -jar /hyst/src/Hyst.jar -help
 # # NOTE: like for a VM, the host system's folders need to be explicitly shared with the guest container.
 # # To map /path_on_host to /data in the container:
-# docker run -v /path_on_host:/data hyst java -jar Hyst.jar -t pysim '' -i /data/foo.xml -o /data/bar.xml
+# docker run -v /path_on_host:/data hyst hyst -t pysim '' -i /data/foo.xml -o /data/bar.xml
 # to delete docker container use: docker rm hyst

--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ There are many tests included with Hyst. There are unit tests (Java JUnit tests)
 
 Before the tools can run, however, you'll need to setup your HYPYPATH to the proper executables, see the hypy section below.
 
+Test coverage of the tests using Python code (mainly for the hypy library) can be generated with src/python_test_coverage.sh .
+
 *******************************
 #### ADDING A NEW PRINTER:
 *******************************
@@ -308,6 +310,8 @@ Currently, Python 2.7 needs to be installed, as well as the following packages:
 * scipy: http://www.scipy.org/install.html
 
 * matplotlib:  http://matplotlib.org/users/installing.html
+
+* coverage
 
 The python executable will be looked for on the paths given in the environment variable HYST_PYTHON_PATH, as well as PATH. It will look for binaries named python2.7 and python.
 

--- a/src/.coveragerc
+++ b/src/.coveragerc
@@ -1,0 +1,16 @@
+# configuration for python-coverage
+[run]
+branch = True
+parallel = True
+# unfortunately broken in python-coverage 4.5: 
+#   concurrency = multiprocessing
+#   (would allow running the integration tests in parallel)
+# threading is used for timeouts:
+concurrency = threading
+
+[report]
+omit = /usr/local/*,/tmp/*
+# ignore_errors = True
+
+[html]
+directory = python_coverage/

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,4 @@
+.coverage
+.coverage.*
+python_coverage/
+

--- a/src/hybridpy/hybridpy/hypy.py
+++ b/src/hybridpy/hybridpy/hypy.py
@@ -298,7 +298,7 @@ class Engine(object):
             elif parse_output:
                 rv['output'] = tool.parse_output(temp_dir, tool_out.lines, hypy_out)
              
-            if temp_dir is not None:   
+            if temp_dir is not None and os.path.exists(temp_dir):   
                 shutil.rmtree(temp_dir)
 
             if save_stdout:

--- a/src/hybridpy/hybridpy/tool_hylaa2.py
+++ b/src/hybridpy/hybridpy/tool_hylaa2.py
@@ -1,7 +1,5 @@
 '''Uses pysim to simulate a hybrid automaton'''
 
-import imp
-import os
 import sys
 import subprocess
 

--- a/src/python_test_coverage.sh
+++ b/src/python_test_coverage.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+echo "Notice: You can speed up this script if you run it as SKIP_MOST_TESTS=1 ./python_test_coverage.sh"
+echo "Then, only a few integration tests will be run"
+cd "$(dirname $0)"
+COVERAGE=python2-coverage
+# note that python2-coverage loads its settings from .coveragerc
+COVERAGE_RUN="$COVERAGE run"
+export NUM_THREADS=1 # workaround because multiprocessing.Pool is currently not supported by python2-coverage, and even causes crashes
+export PYTHON_EXECUTABLE="$COVERAGE_RUN"
+mkdir -p python_coverage
+rm -r python_coverage/
+$COVERAGE erase
+$COVERAGE_RUN tests/integration/run_tests.py
+$COVERAGE_RUN -m unittest discover -v
+# Tests in hybridpy/ are not autodiscovered
+$COVERAGE_RUN -m unittest discover -v -s hybridpy/
+$COVERAGE combine
+$COVERAGE report
+$COVERAGE html
+echo "A detailed report can be found in $(pwd)/python_coverage/index.html"

--- a/src/tests/integration/models/0_toy_safe/toy_safe.cfg
+++ b/src/tests/integration/models/0_toy_safe/toy_safe.cfg
@@ -1,0 +1,19 @@
+system = system
+initially = "loc(toy_1)==loc1 & x==5 & eps==0.1 & t==0 & tglobal==0 & tmax==20"
+output-variables = "t, x"
+#simu-init-sampling-points = 50
+#
+#
+forbidden = "x >= 100"
+scenario = "phaver"
+directions = "oct"
+set-aggregation = "none"
+sampling-time = 0.1
+flowpipe-tolerance = 0.01
+time-horizon = 20
+iter-max = 100
+output-format = "GEN"
+rel-err = 1.0e-3
+abs-err = 1.0e-6
+#verbosity = h
+#clustering = 100

--- a/src/tests/integration/models/0_toy_safe/toy_safe.xml
+++ b/src/tests/integration/models/0_toy_safe/toy_safe.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<sspaceex xmlns="http://www-verimag.imag.fr/xml-namespaces/sspaceex" version="0.2" math="SpaceEx">
+  <component id="toy">
+    <param name="x" type="real" local="false" d1="1" d2="1" dynamics="any" />
+    <param name="t" type="real" local="false" d1="1" d2="1" dynamics="any" />
+    <param name="tglobal" type="real" local="false" d1="1" d2="1" dynamics="any" />
+    <param name="eps" type="real" local="false" d1="1" d2="1" dynamics="const" />
+    <param name="tmax" type="real" local="false" d1="1" d2="1" dynamics="const" />
+    <location id="1" name="loc1" x="385.0" y="216.5" width="379.0" height="124.0">
+      <invariant>x &lt;= 10 &amp;
+t &lt;= tmax &amp;
+tglobal &lt;= tmax</invariant>
+      <flow>x' == 1 &amp;
+t' == 1 &amp;
+tglobal' == 1</flow>
+    </location>
+    <location id="2" name="loc2" x="406.0" y="606.0" width="424.0" height="132.0">
+      <invariant>x &gt;= 2 &amp;
+t &lt;= tmax &amp;
+tglobal &lt;= tmax</invariant>
+      <flow>x' == -2 &amp;
+t' == 1 &amp;
+tglobal' == 1</flow>
+    </location>
+    <transition source="1" target="1" bezier="true">
+      <guard>x &gt;= 9 &amp; 
+t &gt;= eps</guard>
+      <!-- <assignment>x' == 8</assignment> -->
+      <labelposition x="26.0" y="-59.0" width="92.0" height="88.0" />
+      <middlepoint x="486.5" y="399.75" />
+    </transition>
+    <transition source="2" target="1" bezier="true">
+      <guard>x &lt;= 3 &amp; 
+t &gt;= eps</guard>
+      <labelposition x="-123.0" y="-55.0" width="92.0" height="82.0" />
+      <middlepoint x="293.5" y="418.25" />
+    </transition>
+  </component>
+  <component id="system">
+    <param name="x" type="real" local="false" d1="1" d2="1" dynamics="any" controlled="true" />
+    <param name="t" type="real" local="false" d1="1" d2="1" dynamics="any" controlled="true" />
+    <param name="tglobal" type="real" local="false" d1="1" d2="1" dynamics="any" controlled="true" />
+    <param name="eps" type="real" local="false" d1="1" d2="1" dynamics="const" controlled="true" />
+    <param name="tmax" type="real" local="false" d1="1" d2="1" dynamics="const" controlled="true" />
+    <bind component="toy" as="toy_1" x="319.0" y="100.0" width="136.0" height="86.0">
+      <map key="x">x</map>
+      <map key="t">t</map>
+      <map key="tglobal">tglobal</map>
+      <map key="eps">eps</map>
+      <map key="tmax">tmax</map>
+    </bind>
+  </component>
+</sspaceex>
+

--- a/src/tests/integration/models/toy_diverging/toy_diverging.cfg
+++ b/src/tests/integration/models/toy_diverging/toy_diverging.cfg
@@ -1,0 +1,19 @@
+system = system
+initially = "loc(toy_1)==loc1 & x==5 & eps==0.1 & t==0 & tglobal==0 & tmax==20"
+output-variables = "t, x"
+#simu-init-sampling-points = 50
+#
+#
+# forbidden = "loc(toy_1)==loc2"
+scenario = "phaver"
+directions = "oct"
+set-aggregation = "none"
+sampling-time = 0.1
+flowpipe-tolerance = 0.01
+time-horizon = 20
+iter-max = 100
+output-format = "GEN"
+rel-err = 1.0e-3
+abs-err = 1.0e-6
+#verbosity = h
+#clustering = 100

--- a/src/tests/integration/models/toy_diverging/toy_diverging.xml
+++ b/src/tests/integration/models/toy_diverging/toy_diverging.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<sspaceex xmlns="http://www-verimag.imag.fr/xml-namespaces/sspaceex" version="0.2" math="SpaceEx">
+  <component id="toy">
+    <param name="x" type="real" local="false" d1="1" d2="1" dynamics="any" />
+    <param name="t" type="real" local="false" d1="1" d2="1" dynamics="any" />
+    <param name="tglobal" type="real" local="false" d1="1" d2="1" dynamics="any" />
+    <param name="eps" type="real" local="false" d1="1" d2="1" dynamics="const" />
+    <param name="tmax" type="real" local="false" d1="1" d2="1" dynamics="const" />
+    <location id="1" name="loc1" x="385.0" y="216.5" width="379.0" height="124.0">
+      <invariant> t &lt;= 10</invariant>
+      <flow>x' == 1 &amp;
+t' == 1 &amp;
+tglobal' == 1</flow>
+    </location>
+    <location id="2" name="loc2" x="406.0" y="606.0" width="424.0" height="132.0">
+      <invariant>x &gt;= 2 &amp;
+t &lt;= tmax &amp;
+tglobal &lt;= tmax</invariant>
+      <flow>x' == -2 &amp;
+t' == 1 &amp;
+tglobal' == 1</flow>
+    </location>
+    <transition source="1" target="1" bezier="true">
+      <guard>x &gt;= 9 &amp; 
+t &gt;= eps</guard>
+      <assignment>t' == 0 &amp; tglobal' == 0 &amp; x' == 1.001*x</assignment>
+      <labelposition x="26.0" y="-59.0" width="92.0" height="88.0" />
+      <middlepoint x="486.5" y="399.75" />
+    </transition>
+    <transition source="2" target="1" bezier="true">
+      <guard>x &lt;= 3 &amp; 
+t &gt;= eps</guard>
+      <labelposition x="-123.0" y="-55.0" width="92.0" height="82.0" />
+      <middlepoint x="293.5" y="418.25" />
+    </transition>
+  </component>
+  <component id="system">
+    <param name="x" type="real" local="false" d1="1" d2="1" dynamics="any" controlled="true" />
+    <param name="t" type="real" local="false" d1="1" d2="1" dynamics="any" controlled="true" />
+    <param name="tglobal" type="real" local="false" d1="1" d2="1" dynamics="any" controlled="true" />
+    <param name="eps" type="real" local="false" d1="1" d2="1" dynamics="const" controlled="true" />
+    <param name="tmax" type="real" local="false" d1="1" d2="1" dynamics="const" controlled="true" />
+    <bind component="toy" as="toy_1" x="319.0" y="100.0" width="136.0" height="86.0">
+      <map key="x">x</map>
+      <map key="t">t</map>
+      <map key="tglobal">tglobal</map>
+      <map key="eps">eps</map>
+      <map key="tmax">tmax</map>
+    </bind>
+  </component>
+</sspaceex>
+

--- a/src/tests/integration/models/toy_unsafe/toy_unsafe.cfg
+++ b/src/tests/integration/models/toy_unsafe/toy_unsafe.cfg
@@ -1,0 +1,19 @@
+system = system
+initially = "loc(toy_1)==loc1 & x==5 & eps==0.1 & t==0 & tglobal==0 & tmax==20"
+output-variables = "t, x"
+#simu-init-sampling-points = 50
+#
+#
+forbidden = "loc(toy_1)==loc2"
+scenario = "phaver"
+directions = "oct"
+set-aggregation = "none"
+sampling-time = 0.1
+flowpipe-tolerance = 0.01
+time-horizon = 20
+iter-max = 100
+output-format = "GEN"
+rel-err = 1.0e-3
+abs-err = 1.0e-6
+#verbosity = h
+#clustering = 100

--- a/src/tests/integration/models/toy_unsafe/toy_unsafe.xml
+++ b/src/tests/integration/models/toy_unsafe/toy_unsafe.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<sspaceex xmlns="http://www-verimag.imag.fr/xml-namespaces/sspaceex" version="0.2" math="SpaceEx">
+  <component id="toy">
+    <param name="x" type="real" local="false" d1="1" d2="1" dynamics="any" />
+    <param name="t" type="real" local="false" d1="1" d2="1" dynamics="any" />
+    <param name="tglobal" type="real" local="false" d1="1" d2="1" dynamics="any" />
+    <param name="eps" type="real" local="false" d1="1" d2="1" dynamics="const" />
+    <param name="tmax" type="real" local="false" d1="1" d2="1" dynamics="const" />
+    <location id="1" name="loc1" x="385.0" y="216.5" width="379.0" height="124.0">
+      <invariant>x &lt;= 10 &amp;
+t &lt;= tmax &amp;
+tglobal &lt;= tmax</invariant>
+      <flow>x' == 1 &amp;
+t' == 1 &amp;
+tglobal' == 1</flow>
+    </location>
+    <location id="2" name="loc2" x="406.0" y="606.0" width="424.0" height="132.0">
+      <invariant>x &gt;= 2 &amp;
+t &lt;= tmax &amp;
+tglobal &lt;= tmax</invariant>
+      <flow>x' == -2 &amp;
+t' == 1 &amp;
+tglobal' == 1</flow>
+    </location>
+    <transition source="1" target="2" bezier="true">
+      <guard>x &gt;= 9 &amp; 
+t &gt;= eps</guard>
+      <!-- <assignment>x' == 8</assignment> -->
+      <labelposition x="26.0" y="-59.0" width="92.0" height="88.0" />
+      <middlepoint x="486.5" y="399.75" />
+    </transition>
+    <transition source="2" target="1" bezier="true">
+      <guard>x &lt;= 3 &amp; 
+t &gt;= eps</guard>
+      <labelposition x="-123.0" y="-55.0" width="92.0" height="82.0" />
+      <middlepoint x="293.5" y="418.25" />
+    </transition>
+  </component>
+  <component id="system">
+    <param name="x" type="real" local="false" d1="1" d2="1" dynamics="any" controlled="true" />
+    <param name="t" type="real" local="false" d1="1" d2="1" dynamics="any" controlled="true" />
+    <param name="tglobal" type="real" local="false" d1="1" d2="1" dynamics="any" controlled="true" />
+    <param name="eps" type="real" local="false" d1="1" d2="1" dynamics="const" controlled="true" />
+    <param name="tmax" type="real" local="false" d1="1" d2="1" dynamics="const" controlled="true" />
+    <bind component="toy" as="toy_1" x="319.0" y="100.0" width="136.0" height="86.0">
+      <map key="x">x</map>
+      <map key="t">t</map>
+      <map key="tglobal">tglobal</map>
+      <map key="eps">eps</map>
+      <map key="tmax">tmax</map>
+    </bind>
+  </component>
+</sspaceex>
+

--- a/src/tests/integration/run_tests.py
+++ b/src/tests/integration/run_tests.py
@@ -7,6 +7,7 @@ import os
 import sys
 import shutil
 import multiprocessing
+import hybridpy.hybrid_tool
 from hybridpy.hybrid_tool import get_script_path
 import hybridpy.hypy as hypy
 from hybridpy.hypy import Engine
@@ -15,7 +16,8 @@ from hybridpy.hypy import Engine
 TIMEOUT = 2.0
 
 SHOULD_RUN_TOOLS = True
-NUM_THREADS = multiprocessing.cpu_count()
+# autodetect number of threads (override with NUM_THREADS)
+NUM_THREADS = int(os.environ.get("NUM_THREADS", multiprocessing.cpu_count()))
 
 if sys.platform == "win32":
     SHOULD_RUN_TOOLS = False
@@ -26,9 +28,10 @@ MODELS_PATH = get_script_path(__file__) + "/models"
 
 # a list of tools to run: each element is (tool_name, tool_param)
 TOOLS = [(hypy_tool_name, None) for hypy_tool_name in hypy.TOOLS]
-
-# extra tools (manual)
-#TOOLS.append({'name':'hycreate', 'param':'sim-only=1'})
+# manually set / add tools (tool name, hyst printer parameters)
+# TOOLS=[]
+# TOOLS.append(('spaceex', '-output-format INTV'))
+# TOOLS.append(('hylaa', ''))
 
 # the path where to put results (plots/models/work dir), relative to this script
 RESULT_PATH = get_script_path(__file__) + "/result"
@@ -56,28 +59,66 @@ def run_single((index, total, path, tool_tuple, quit_flag)):
     e.set_input(path)
     e.set_output(base + hypy.TOOLS[tool_name].default_ext())
 
-    to = TIMEOUT
+    current_timeout = TIMEOUT
 
-    print "{}/{} Running {} with {} and timeout {}".format(index, total, model, tool_name, to)
+    allowed_results = [Engine.SUCCESS]
+    NONLINEAR_MODELS = ['biology7d', 'biology9d', 'brusselator', 'coupled_vanderpol', 'vanderpol', 'lorenz', 'stable_3d', 'neuron']
+    # Ignore rules: Which errors are okay? Which models need a longer timeout?
+    if tool_name == 'hylaa' and model in NONLINEAR_MODELS + ['pd_lut_linear']:
+        # unsupported dynamics for hylaa
+        allowed_results += [Engine.ERROR_UNSUPPORTED]
+    if tool_name == 'dreach' and model in NONLINEAR_MODELS + ['cont_approx', 'pd_lut_linear']:
+        # unsupported dynamics
+        allowed_results += [Engine.ERROR_UNSUPPORTED]
+    if tool_name == 'spaceex' and model in NONLINEAR_MODELS:
+        # unsupported dynamics
+        allowed_results += [Engine.ERROR_UNSUPPORTED]
+
+    # if tool_name == 'my_broken_tool' and model in ['foo', 'bar']:
+    #    allowed_results += [Engine.ERROR_UNSUPPORTED, Engine.ERROR_TOOL, Engine.ERROR_CONVERSION]
+    if tool_name == 'hylaa' and model == 'toy_diverging':
+        # Hylaa doesn't abort the computation for this diverging automaton
+        allowed_results += [Engine.TIMEOUT_TOOL]    
+    elif 'toy' in model:
+        # for the trivial examples, give plenty of time,
+        # do not allow a timeout
+        current_timeout += 60
+    else:
+        # for nontrivial examples, timeout is okay; we are happy if the tool starts without crashing
+        # FIXME: is this really what we want?
+        allowed_results += [Engine.TIMEOUT_TOOL]
+    
+    print "{}/{} Running {} with {} and timeout {}".format(index, total, model, tool_name, current_timeout)
     sys.stdout.flush()
 
-    result = e.run(run_tool=SHOULD_RUN_TOOLS, timeout=to, save_stdout=True, image_path=base + ".png")
+    
+    # enable 'parse_output' if the tool overrides the parse_output() method
+    tool_supports_parse_output = (hypy.TOOLS[tool_name].parse_output.__code__ is not hybridpy.hybrid_tool.HybridTool.parse_output.__code__)
 
-    if result['code'] in [Engine.ERROR_TOOL, Engine.ERROR_CONVERSION, Engine.TIMEOUT_CONVERSION]:
-        message = "Test failed for {}/{} model {} with {}: {}".format(index, total, model, tool_name, result['code'])
+    result = e.run(run_tool=SHOULD_RUN_TOOLS, timeout=current_timeout, save_stdout=True, image_path=base + ".png", parse_output=tool_supports_parse_output)
+
+
+    if result['code'] not in allowed_results:
+        message = "Test failed for {}/{} model {} with {}: {}. (If this is not an error, add an ignore rule to src/tests/integration/run_test.py.".format(index, total, model, tool_name, result['code'])
 
         log = "\n".join(result['stdout'])
 
         rv = (message, log)
         quit_flag.value = 1
+    elif result['code'] != Engine.SUCCESS:
+        print("Notice: Ignoring test result for {}/{} model {} with {}: {}".format(index, total, model, tool_name, result['code']))        
 
     print "{}/{} Finished {} with {}".format(index, total, model, tool_name)
 
     return rv
-
 def file_tool_iter(file_list, quit_flag):
     '''iterator over all model files and tools'''
 
+    speedup = False
+    if os.environ.get('SKIP_MOST_TESTS'):
+        print "Skipping most tests because SKIP_MOST_TESTS is set"
+        speedup = True
+    
     index = 0
     total = len(TOOLS) * len(file_list)
 
@@ -87,7 +128,10 @@ def file_tool_iter(file_list, quit_flag):
     for tool in TOOLS:
         yield (index, total, f, tool, quit_flag)
         index = index + 1
-
+    
+    if speedup:
+        print("Skipping remaining tests")
+        return
     # then run one tool on all models
     for tool in TOOLS:
         for f_index in xrange(1, len(file_list)):


### PR DESCRIPTION
This adds a coverage report for all Python code and strengthens the integration tests. (Currently, some tools failed with timeout for every single system in the integration test, so the result parsing was never tested. This could be seen from rather bad test coverage. Now, some simple models are run to completion.)

It seems that most basic features of hypy are now tested. There are still a few relevant gaps (e.g., parsing the INTV output of SpaceEx), so in total the coverage is 69%, whereas it could be around 85% with reasonable effort (maybe one workday). The remaining 15% are rare edge cases (e.g., error handling), which are in my opinion not worth the effort.

My plan would be to continue by making the code compatible with Python 3, while preserving Python 2 compatibility.