### PR TITLE
fix SpaceEx set-aggregation parameter

### DIFF
--- a/src/java/com/verivital/hyst/printers/SpaceExPrinter.java
+++ b/src/java/com/verivital/hyst/printers/SpaceExPrinter.java
@@ -57,6 +57,7 @@ import de.uni_freiburg.informatik.swt.sxhybridautomaton.VariableParam;
  */
 public class SpaceExPrinter extends ToolPrinter
 {
+	// NOTE: "auto" is a magic constant that means "unset, fall back to default". See convert().
 	@Option(name = "-time", usage = "reachability time", metaVar = "VAL")
 	String time = "auto";
 
@@ -76,7 +77,7 @@ public class SpaceExPrinter extends ToolPrinter
 	String directions = "auto";
 
 	@Option(name = "-aggregation", usage = "aggregation parameter", metaVar = "VAL")
-	String aggregation = "chull";
+	String aggregation = "auto";
 
 	@Option(name = "-forbidden", usage = "forbidden parameter", metaVar = "VAL")
 	String forbidden = "none";

--- a/src/java/de/uni_freiburg/informatik/swt/spaceexxmlprinter/SpaceExXMLPrinter.java
+++ b/src/java/de/uni_freiburg/informatik/swt/spaceexxmlprinter/SpaceExXMLPrinter.java
@@ -656,9 +656,7 @@ public class SpaceExXMLPrinter
 		appendCfgString(rv, "system", config.systemID);
 		appendCfgString(rv, "scenario", config.scenario); // was supp
 		appendCfgString(rv, "directions", config.directions);
-
-		if (!config.aggregation.toLowerCase().equals("none"))
-			appendCfgString(rv, "set-aggregation", config.aggregation);
+		appendCfgString(rv, "set-aggregation", config.aggregation);
 
 		if (config.flowpipeTol > 0)
 			appendCfgString(rv, "flowpipe-tolerance", Double.toString(config.flowpipeTol));


### PR DESCRIPTION
The setting set-aggregation=<value> from the SpaceEx .cfg file was ignored and changed to set-aggregation=chull, which yields different results.

This is a regression from commit 1591f8393113efb2d29c31a1da63bcada525d151. @stanleybak  Could you please have a look if this doesn't break the change you intended in that commit?

Test case for correct behavior:
```
$ java -jar /hyst/src/Hyst.jar -tool spaceex '' -i /hyst/examples/toy/toy.xml -o /tmp/toy.xml
$ cat /hyst/examples/toy/toy.cfg | grep set-aggregation
set-aggregation = "none"
$ cat /tmp/toy.cfg  | grep set-aggregation
set-aggregation = none
$ java -jar /hyst/src/Hyst.jar -tool spaceex '' -i /hyst/examples/vanderpol/vanderpol.xml -o /tmp/vanderpol.xml
$ cat /hyst/examples/vanderpol/vanderpol.xml | grep set-aggregation
$ cat /hyst/examples/vanderpol/vanderpol.cfg | grep set-aggregation
set-aggregation = chull
$ cat /tmp/vanderpol.cfg | grep set-aggregation
set-aggregation = chull
$ java -jar /hyst/src/Hyst.jar -tool spaceex '-aggregation foobar' -i /hyst/examples/vanderpol/vanderpol.xml -o /tmp/vanderpol.xml
$ cat /tmp/vanderpol.cfg | grep set-aggregation
set-aggregation = foobar
```

Before, `set-aggregation=none` in the input config was changed to `set-aggregation=chull` in the output config.